### PR TITLE
Update RabbitMessage a wee bit to encourage better practice

### DIFF
--- a/src/main/java/com/github/maxopoly/zeus/rabbit/RabbitMessage.java
+++ b/src/main/java/com/github/maxopoly/zeus/rabbit/RabbitMessage.java
@@ -1,5 +1,6 @@
 package com.github.maxopoly.zeus.rabbit;
 
+import java.util.Objects;
 import org.json.JSONObject;
 
 import com.google.common.base.Preconditions;
@@ -10,11 +11,25 @@ import com.google.common.base.Preconditions;
  */
 public abstract class RabbitMessage {
 
+	public static final String TYPE_KEY = "%%type";
+	public static final String TRANSACTION_KEY = "%%transaction_id";
+
 	private final String transactionID;
 
 	public RabbitMessage(String transactionID) {
-		Preconditions.checkNotNull(transactionID);
-		this.transactionID = transactionID;
+		this.transactionID = Objects.requireNonNull(transactionID,
+				"RabbitMessage requires a transaction id!");
+	}
+
+	/**
+	 * This is a deserialisation constructor, the counterpart to {@link #enrichJson(JSONObject)}. You should include
+	 * this type of constructor in all your packets to keep serialisation and deserialisation in one place.
+	 *
+	 * @param json The JSON object to deserialise from.
+	 */
+	public RabbitMessage(final JSONObject json) {
+		this(Objects.requireNonNull(json.getString(TRANSACTION_KEY),
+				"RabbitMessage requires a valid object to deserialise!"));
 	}
 
 	/**
@@ -25,8 +40,8 @@ public abstract class RabbitMessage {
 	 */
 	public JSONObject getJSON() {
 		JSONObject json = new JSONObject();
-		json.put("%%type", getIdentifier());
-		json.put("%%transaction_id", transactionID);
+		json.put(TYPE_KEY, getIdentifier());
+		json.put(TRANSACTION_KEY, this.transactionID);
 		enrichJson(json);
 		return json;
 	}
@@ -47,7 +62,7 @@ public abstract class RabbitMessage {
 	 * @return ID uniquely identifying this message exchange
 	 */
 	public String getTransactionID() {
-		return transactionID;
+		return this.transactionID;
 	}
 
 }


### PR DESCRIPTION
As of right now, Zeus doesn't fully encapsulate packet data. What I mean is that Zeus has a [packet wrapper for sending](https://github.com/DevotedMC/Zeus/blob/0f86a5665363cf9485bd1b7737c3963a278cb292/src/main/java/com/github/maxopoly/zeus/rabbit/outgoing/artemis/SendPlayerData.java#L24) but [when receiving](https://github.com/DevotedMC/Artemis/blob/85b08f6119973648e908c86a52bbd83d946b57e4/src/main/java/com/github/maxopoly/artemis/rabbit/incoming/playertransfer/ReceivePlayerData.java), it's deserialised by manually rummaging through the raw json. This PR adds an additional constructor (which should come up "create super" class constructor creation) making it easier, but not required, for people to add deserialisation directly onto the packet class itself, which is made easier by the static-ification of the type and transaction id keys.

Below is an example of what this could mean:

```java
package io.protonull.example.protocol.zeus;

import com.github.maxopoly.zeus.model.ZeusLocation;
import com.github.maxopoly.zeus.rabbit.RabbitMessage;
import com.github.maxopoly.zeus.util.Base64Encoder;
import java.util.Objects;
import java.util.UUID;
import org.apache.commons.lang3.ArrayUtils;
import org.json.JSONObject;

/**
 * This is sent by Zeus in response to {@link RequestPlayerDataForShard} and
 * contains the player's NBT data.
 */
public class RequestPlayerDataForShardAccepted extends RabbitMessage {

    public static final String ID = "send_player_data";

    private static final String PLAYER_KEY = "player";
    private static final String NEW_PLAYER_KEY = "new_player";
    private static final String LOCATION_KEY = "loc";
    private static final String DATA_KEY = "data";

    private final UUID player;
    private final byte[] data;
    private final ZeusLocation destination;

    public RequestPlayerDataForShardAccepted(final String transaction,
                                             final UUID player,
                                             final byte[] data,
                                             final ZeusLocation destination) {
        super(transaction);
        this.player = Objects.requireNonNull(player);
        this.data = data == null ? new byte[0] : data;
        this.destination = Objects.requireNonNull(destination);
    }

    public RequestPlayerDataForShardAccepted(final JSONObject json) {
        super(json);
        this.player = UUID.fromString(json.getString(PLAYER_KEY));
        if (json.has(NEW_PLAYER_KEY)) {
            this.data = new byte[0];
        }
        else {
            this.data = Base64Encoder.decode(json.getString(DATA_KEY));
        }
        this.destination = ZeusLocation.parseLocation(json);
    }

    @Override
    public String getIdentifier() {
        return ID;
    }

    @Override
    protected void enrichJson(final JSONObject json) {
        json.put(PLAYER_KEY, this.player);
        if (isNewPlayer()) {
            json.put(NEW_PLAYER_KEY, true);
        }
        else {
            json.put(DATA_KEY, Base64Encoder.encode(this.data));
        }
        final JSONObject loc = new JSONObject();
        this.destination.writeToJson(loc);
        json.put(LOCATION_KEY, loc);
    }

    public UUID getPlayer() {
        return this.player;
    }

    public boolean isNewPlayer() {
        return ArrayUtils.isEmpty(this.data);
    }

    public byte[] getData() {
        return this.data;
    }

    public ZeusLocation getDestination() {
        return this.destination;
    }

}
```

None of this is forced upon the developer, they can continue creating wrapped outgoing packets and access the incoming data directly, but it also allows developers to very easily pass the received JSON object into the packet class and use the getters instead :)